### PR TITLE
load / dump reversed in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Example
             author = fields.String()
             publisher = fields.String()
 
-            # NOTE: Marshmallow uses the `missing` keyword during deserialization, which occurs when we save
-            # an object to Dynamo and the attr has no value, versus the `default` keyword, which is used when
-            # we load a document from Dynamo and the value doesn't exist or is null.
+            # NOTE: Marshmallow uses the `missing` keyword during deserialization, which occurs when we load
+            # an object from Dynamo and the value doesn't exist or is null, versus the `default` keyword,
+            # which is used when we save a document to Dynamo and the attr has no value.
             year = fields.Number(missing=lambda: datetime.datetime.utcnow().year)
 
 


### PR DESCRIPTION
Dont we serialize when dumping to Dynamo and deserialize when loading from?
Pretty sure this logic was stated in reverse.